### PR TITLE
Implement Login über OIDC

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ flask-login==0.6.2
 flask-ldap3-login==0.9.18
 flask-WTF==1.2.1
 wtforms==3.0.1
+simple_openid_connect~=0.5.0
 
 Werkzeug==2.3.7

--- a/static/style.css
+++ b/static/style.css
@@ -145,3 +145,37 @@ input[type=submit] {
   align-self: start;
   min-width: 10em;
 }
+
+.login-container {
+  display: flex;
+  justify-content: space-between;
+  gap: 32px;
+}
+
+.login-container > * {
+  flex-grow: 1;
+}
+
+.login-container > *:nth-child(2) {
+  flex-grow: 0;
+  background-color: lightgray;
+  width: 4px;
+  border-radius: 64px;
+  margin: 16px 0;
+}
+
+.keycloak-login-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.keycloak-login-container > a {
+  width: 70%;
+  height: 3em;
+}
+
+.keycloak-login-container > a > button {
+  width: 100%;
+  height: 100%;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -72,8 +72,21 @@ nav ul li a, nav ul li span, header .action {
 .flash {
   margin: 1em 0;
   padding: 1em;
+}
+
+.flash.flash-message,.flash.flash-info {
   background: #cae6f6;
   border: 1px solid #377ba8;
+}
+
+.flash.flash-warning {
+  background: #f6e6ca;
+  border: 1px solid #aba37f;
+}
+
+.flash.flash-error {
+  background: #ffbebe;
+  border: 1px solid #a84e4e;
 }
 
 .post > header {

--- a/templates/login.html
+++ b/templates/login.html
@@ -9,18 +9,31 @@
 <section class="content">
     <header><h2> Login </h2></header>
 
-    {% for message in get_flashed_messages() %}
-        <div class="flash">{{ message }}</div>
+    {% for (msg_category, message) in get_flashed_messages(with_categories=True) %}
+        <div class="flash flash-{{ msg_category }}">{{ message }}</div>
     {% endfor %}
-    {% if form.errors %}
-        {{ form.errors }}
-    {% endif %}
-    <form method="post">
-        {{ form.username.label }} {{ form.username() }}
-        {{ form.password.label }} {{ form.password() }}
-        {{ form.submit() }}
-        {{ form.hidden_tag() }}
-    </form>
+
+    <div class="login-container">
+        <div>
+            {% if form.errors %}
+                {{ form.errors }}
+            {% endif %}
+            <form method="post">
+                {{ form.username.label }} {{ form.username() }}
+                {{ form.password.label }} {{ form.password() }}
+                {{ form.submit() }}
+                {{ form.hidden_tag() }}
+            </form>
+        </div>
+
+        <div></div>
+
+        <div class="keycloak-login-container">
+            <a href="{{ oidc_login_url }}">
+                <button>Login with Keycloak</button>
+            </a>
+        </div>
+    </div>
 </section>
 </body>
 </html>


### PR DESCRIPTION
closes #16 

Wie erwähnt implementiere ich in dieser PR login mit OpenidConnect.
Das Login-Formular sieht nun dadurch so aus:
![image](https://github.com/Queer-Lexikon/passworttool/assets/12398140/c286c5ed-e5df-4f84-aac0-ca255bff9417)

Zusätzlich habe ich noch implementiert, dass die flash-messages jetzt die kateogrien `info`, `warning` und `error` in unterschiedlichen farben anzeigen, weil ich die nutze, wenn der openid login aus *Gründen* nicht funktioniert.

## Implementationsdetails:
- Ich verwende hierfür die Library [simple_openid_connect](https://simple-openid-connect.readthedocs.io/en/stable/installation.html), die bei uns an der Uni-Hamburg von der Fachschaft entwickelt wird und so grundsätzliche Dinge übernimmt, wie die Validierung von Tokens, das parsen der verschiedenen URL-Parameter und dem Code-for-Token-Exchange.
- Die Implementation verwendet den *authorization code flow* (Keycloak nennt den *Standard Flow*). 
- Die redirect-url, die für OIDC-Login benötigt wird, wird automatisch aus der aktuellen request generiert, wenn `/login` das erste mal aufgerufen wird ([app.py:90](https://github.com/ftsell/queerlexikon-passworttool/blob/main/app.py#L90))
- Es gibt ein paar neue einstellungen, die aus `config.json` eingelesen werden.
    - `OIDC_ISSUER` z.B. `https://auth.example.com/realms/queerlexikon` für Keycloak. Hieraus wird automatisch das Openid Autokonfigurations-Dokument abgerufen, um die verschiedenen openid endpoints zu entdecken.
    - `OIDC_CLIENT_ID`
    - `OIDC_CLIENT_SECRET`
    - `OIDC_SCOPE` defaulted auf `openid` und ist der scope, der vom openid issuer requested wird.
 - Der Hauptteil des logins passiert im `login_oidc_callback` ([app.py:67](https://github.com/ftsell/queerlexikon-passworttool/blob/main/app.py#L67)). Da ich mir nicht ganz sicher war, wie das `users = {}` dictionary befüllt wird, aus dem `load_user()` das user objekt läd, kann es sein, dass der Teil entsprechend nicht richtig funktioniert ([app.py:78](https://github.com/ftsell/queerlexikon-passworttool/blob/main/app.py#L78)). Insbesondere, wenn die Keycloak IDs nicht die gleichen sind, wie die, die hier als `id` bezeichnet werden kann das noch kaputt sein.